### PR TITLE
Fix of issue3 and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["audio", "sound", "playback", "wav", "windows"]
 categories = ["api-bindings", "multimedia::audio", "os::windows-apis"]
 
 [target.'cfg(windows)'.dependencies]
-widestring = "0.4.3"
+widestring = "1.1.0"
 winapi = { version = "0.3", features = ["mmsystem", "mmeapi"] }
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,10 @@
 //! ```no_run
 //! use winaudio::wave::Player;
 //!
-//! fn main() {
 //!     let mut player = Player::from_file("test.wav").unwrap();
 //!     player.play().unwrap();
-//! }
 //! ```
-//! 
+//!
 //! If you're missing a certain function from the [mmeapi.h header], feel free to open an issue
 //! or send a pull request to the project to add it. This initial version doesn't have methods to
 //! set the pitch or playback rate for example, but they can trivially be added if needed.

--- a/src/util.rs
+++ b/src/util.rs
@@ -51,13 +51,13 @@ macro_rules! enum_with_try_from {
 pub(crate) trait BinaryRead: Read {
     fn read_u16(&mut self) -> io::Result<u16> {
         let mut buffer = [0; 2];
-        self.read(&mut buffer)?;
+        self.read_exact(&mut buffer)?;
         Ok(u16::from_le_bytes(buffer))
     }
 
     fn read_u32(&mut self) -> io::Result<u32> {
         let mut buffer = [0; 4];
-        self.read(&mut buffer)?;
+        self.read_exact(&mut buffer)?;
         Ok(u32::from_le_bytes(buffer))
     }
 }

--- a/src/wave/format.rs
+++ b/src/wave/format.rs
@@ -581,9 +581,8 @@ pub struct Format {
 
 impl Format {
     /// Fill the format structure from the stream of a `.wav` file.
-    pub fn from_wav_stream<S: Read + Seek>(file: &mut S) -> io::Result<Self> {
-        const WF_OFFSET_FORMATTAG: u64 = 20;
-        file.seek(SeekFrom::Start(WF_OFFSET_FORMATTAG))?;
+    pub fn from_wav_stream<S: Read + Seek>(file: &mut S, offset: u64) -> io::Result<Self> {
+        file.seek(SeekFrom::Start(offset))?;
 
         Ok(Self {
             format_tag: file.read_u16()?.try_into().map_err(|tag| {


### PR DESCRIPTION
The issue is fixed in devices.rs::name()
Other changes:
- Added some unit tests in devices.rs
- Some minor changes due to clippy suggestions
- Added _out.rs::get_volume()_ because I need it in my application
- The original code handles only 'canonical' wav files. These are files containing only RIFF chunks.
   In _player.rs::from_file()_ I updated the wav format checking to accept also files with other chunk types.

Tests are made with files from _C:\Windows\Media_ and files recorded with the AudioRecorder application from W11.